### PR TITLE
Player movement update

### DIFF
--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -209,7 +209,7 @@ animations = [{
 }],
 "loop": true,
 "name": &"walk",
-"speed": 5.0
+"speed": 25.0
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5v3d6"]
@@ -261,6 +261,7 @@ scale = Vector2(0.5, 0.5)
 sprite_frames = SubResource("SpriteFrames_8rt8a")
 animation = &"walk"
 frame = 19
+frame_progress = 0.904561
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0.5, 5)

--- a/Scripts/Characters/Player/Player.cs
+++ b/Scripts/Characters/Player/Player.cs
@@ -43,7 +43,20 @@ public partial class Player : CharacterBody2D
         Vector2 direction = Input.GetVector("move_left", "move_right", "move_up", "move_down");
         if (direction != Vector2.Zero)
         {
-            _velocity.X = direction.X * Speed;
+
+            // Normalize only if both horizontal and vertical inputs are non-zero
+            if (direction.X != 0 && direction.Y != 0)
+            {
+                direction = direction.Normalized();
+                // Add 1/2 speed to account for multi-directional input slowdown while grounded
+                _velocity.X = direction.X * (Speed + Speed / 2);
+            }
+            else
+            {
+                // Apply the speed
+                _velocity.X = direction.X * Speed;
+            }
+
             // Store the last horizontal input direction for flipping the sprite
             if (direction.X < 0)
                 _lastHorizontalInput = "left";


### PR DESCRIPTION
Line 50 may not be needed, but as I understand it, normalizing movement is a standard for diagonal movement.

In order to fix the half move speed issue while grounded and pressing up and down, I'm adding half of the move speed back into the speed calculation as seen on line 52.

On a minor note, I updated the animation speed from 5FPS to 25.